### PR TITLE
Add TelemetryDeck SDK integration for privacy-focused analytics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         versionName = "v2.0vc$versionCode"
         @Suppress("UnstableApiUsage")
         androidResources.localeFilters += listOf("en", "ar", "de")
-        manifestPlaceholders["telemetryDeckAppId"] = "YOUR-TELEMETRYDECK-APP-ID"
+        manifestPlaceholders["telemetryDeckAppId"] = "613251CD-B223-443A-9583-3A18586FAB55"
     }
     buildTypes {
         release {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
         versionName = "v2.0vc$versionCode"
         @Suppress("UnstableApiUsage")
         androidResources.localeFilters += listOf("en", "ar", "de")
+        manifestPlaceholders["telemetryDeckAppId"] = "YOUR-TELEMETRYDECK-APP-ID"
     }
     buildTypes {
         release {
@@ -68,5 +69,6 @@ dependencies {
 
     // Third-party
     implementation(libs.boehrsi.devicemarketingnames)
+    implementation(libs.telemetrydeck.sdk)
     implementation(libs.topjohnwu.libsu.core)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <uses-sdk tools:overrideLibrary="androidx.core.splashscreen" />
 
     <application
@@ -31,6 +33,9 @@
                 android:name="autoStoreLocales"
                 android:value="true" />
         </service>
+        <meta-data
+            android:name="com.telemetrydeck.appID"
+            android:value="${telemetryDeckAppId}" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/iboalali/basicrootchecker/analytics/Analytics.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/analytics/Analytics.kt
@@ -1,0 +1,21 @@
+package com.iboalali.basicrootchecker.analytics
+
+import com.telemetrydeck.sdk.TelemetryDeck
+
+object Analytics {
+
+    fun trackNavigation(sourcePath: String, destinationPath: String) {
+        TelemetryDeck.navigate(sourcePath, destinationPath)
+    }
+
+    fun trackRootCheckStarted() {
+        TelemetryDeck.signal("rootCheckStarted")
+    }
+
+    fun trackRootCheckResult(result: String) {
+        TelemetryDeck.signal(
+            "rootCheckCompleted",
+            mapOf("result" to result),
+        )
+    }
+}

--- a/app/src/main/java/com/iboalali/basicrootchecker/analytics/Analytics.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/analytics/Analytics.kt
@@ -12,6 +12,10 @@ object Analytics {
         TelemetryDeck.signal("rootCheckStarted")
     }
 
+    fun trackPrivacyPolicyClicked() {
+        TelemetryDeck.signal("privacyPolicyClicked")
+    }
+
     fun trackOtherAppClicked(packageName: String) {
         TelemetryDeck.signal(
             "otherAppClicked",

--- a/app/src/main/java/com/iboalali/basicrootchecker/analytics/Analytics.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/analytics/Analytics.kt
@@ -12,6 +12,13 @@ object Analytics {
         TelemetryDeck.signal("rootCheckStarted")
     }
 
+    fun trackOtherAppClicked(packageName: String) {
+        TelemetryDeck.signal(
+            "otherAppClicked",
+            mapOf("packageName" to packageName),
+        )
+    }
+
     fun trackRootCheckResult(result: String) {
         TelemetryDeck.signal(
             "rootCheckCompleted",

--- a/app/src/main/java/com/iboalali/basicrootchecker/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/navigation/AppNavigation.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
+import com.iboalali.basicrootchecker.analytics.Analytics
 import com.iboalali.basicrootchecker.ui.about.AboutScreen
 import com.iboalali.basicrootchecker.ui.licence.LicenceScreen
 import com.iboalali.basicrootchecker.ui.main.MainScreen
@@ -47,20 +48,32 @@ fun AppNavigation() {
         entryProvider = entryProvider {
             entry<MainRoute> {
                 MainScreen(
-                    onNavigateToAbout = { backStack.add(AboutRoute) },
-                    onNavigateToLicence = { backStack.add(LicenceRoute) },
+                    onNavigateToAbout = {
+                        Analytics.trackNavigation("Main", "About")
+                        backStack.add(AboutRoute)
+                    },
+                    onNavigateToLicence = {
+                        Analytics.trackNavigation("Main", "Licence")
+                        backStack.add(LicenceRoute)
+                    },
                 )
             }
 
             entry<AboutRoute> {
                 AboutScreen(
-                    onNavigateBack = { backStack.removeLastOrNull() },
+                    onNavigateBack = {
+                        Analytics.trackNavigation("About", "Main")
+                        backStack.removeLastOrNull()
+                    },
                 )
             }
 
             entry<LicenceRoute> {
                 LicenceScreen(
-                    onNavigateBack = { backStack.removeLastOrNull() },
+                    onNavigateBack = {
+                        Analytics.trackNavigation("Licence", "Main")
+                        backStack.removeLastOrNull()
+                    },
                 )
             }
         },

--- a/app/src/main/java/com/iboalali/basicrootchecker/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/navigation/AppNavigation.kt
@@ -49,11 +49,11 @@ fun AppNavigation() {
             entry<MainRoute> {
                 MainScreen(
                     onNavigateToAbout = {
-                        Analytics.trackNavigation("Main", "About")
+                        Analytics.trackNavigation("/main", "/about")
                         backStack.add(AboutRoute)
                     },
                     onNavigateToLicence = {
-                        Analytics.trackNavigation("Main", "Licence")
+                        Analytics.trackNavigation("/main", "/licence")
                         backStack.add(LicenceRoute)
                     },
                 )
@@ -62,7 +62,7 @@ fun AppNavigation() {
             entry<AboutRoute> {
                 AboutScreen(
                     onNavigateBack = {
-                        Analytics.trackNavigation("About", "Main")
+                        Analytics.trackNavigation("/about", "/main")
                         backStack.removeLastOrNull()
                     },
                 )
@@ -71,7 +71,7 @@ fun AppNavigation() {
             entry<LicenceRoute> {
                 LicenceScreen(
                     onNavigateBack = {
-                        Analytics.trackNavigation("Licence", "Main")
+                        Analytics.trackNavigation("/licence", "/main")
                         backStack.removeLastOrNull()
                     },
                 )

--- a/app/src/main/java/com/iboalali/basicrootchecker/ui/about/OtherAppsCard.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/ui/about/OtherAppsCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.iboalali.basicrootchecker.R
+import com.iboalali.basicrootchecker.analytics.Analytics
 import com.iboalali.basicrootchecker.ui.theme.BasicRootCheckerTheme
 import com.iboalali.basicrootchecker.util.PreviewLocales
 import androidx.core.net.toUri
@@ -74,7 +75,10 @@ fun OtherAppsCard(
             filteredApps.forEach { app ->
                 OtherAppItem(
                     app = app,
-                    onClick = { openPlayStoreListing(context, app.packageName) },
+                    onClick = {
+                        Analytics.trackOtherAppClicked(app.packageName)
+                        openPlayStoreListing(context, app.packageName)
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/iboalali/basicrootchecker/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/ui/main/MainScreen.kt
@@ -75,6 +75,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.core.net.toUri
 import com.iboalali.basicrootchecker.R
+import com.iboalali.basicrootchecker.analytics.Analytics
 import com.iboalali.basicrootchecker.ui.theme.BasicRootCheckerTheme
 import com.iboalali.basicrootchecker.util.PreviewLocales
 import kotlinx.coroutines.launch
@@ -144,6 +145,7 @@ fun MainScreenContent(
                             text = { Text(stringResource(R.string.action_privacy_policy)) },
                             onClick = {
                                 menuExpanded = false
+                                Analytics.trackPrivacyPolicyClicked()
                                 context.startActivity(
                                     Intent(
                                         Intent.ACTION_VIEW,

--- a/app/src/main/java/com/iboalali/basicrootchecker/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/ui/main/MainScreen.kt
@@ -3,6 +3,7 @@ package com.iboalali.basicrootchecker.ui.main
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
@@ -72,6 +73,7 @@ import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.core.net.toUri
 import com.iboalali.basicrootchecker.R
 import com.iboalali.basicrootchecker.ui.theme.BasicRootCheckerTheme
 import com.iboalali.basicrootchecker.util.PreviewLocales
@@ -101,6 +103,7 @@ fun MainScreenContent(
     onNavigateToAbout: () -> Unit,
     onNavigateToLicence: () -> Unit,
 ) {
+    val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     var menuExpanded by remember { mutableStateOf(false) }
@@ -135,6 +138,18 @@ fun MainScreenContent(
                             onClick = {
                                 menuExpanded = false
                                 onNavigateToLicence()
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.action_privacy_policy)) },
+                            onClick = {
+                                menuExpanded = false
+                                context.startActivity(
+                                    Intent(
+                                        Intent.ACTION_VIEW,
+                                        "https://iboalali.com/app/basic_root_checker/".toUri(),
+                                    )
+                                )
                             },
                         )
                         DropdownMenuItem(

--- a/app/src/main/java/com/iboalali/basicrootchecker/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/iboalali/basicrootchecker/ui/main/MainViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.iboalali.basicrootchecker.R
+import com.iboalali.basicrootchecker.analytics.Analytics
 import com.iboalali.basicrootchecker.data.RootChecker
 import com.iboalali.basicrootchecker.util.DeviceInfo
 import de.boehrsi.devicemarketingnames.DeviceMarketingNames
@@ -54,6 +55,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun checkRoot() {
         viewModelScope.launch {
             _uiState.update { it.copy(rootStatus = RootStatus.CHECKING) }
+            Analytics.trackRootCheckStarted()
             val result = RootChecker.checkRoot()
             val status = when (result) {
                 true -> RootStatus.ROOTED
@@ -61,6 +63,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 null -> RootStatus.UNKNOWN
             }
             _uiState.update { it.copy(rootStatus = status) }
+            Analytics.trackRootCheckResult(status.name)
         }
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -8,6 +8,7 @@
     <string name="rootNotAvailable">لا يوجد خاصية الـ Root</string>
     <string name="action_licence">حقوق</string>
     <string name="action_about">عنا</string>
+    <string name="action_privacy_policy">سياسة الخصوصية</string>
 
     <!-- About Strings -->
     <string name="about_part1">حقوق الطبع محفوظ 2026 iboalali\n\n

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -8,6 +8,7 @@ Diese app erfordert ROOT zugriff, benutzen auf eigener gefahr.\n
 Diese app sammelt keine daten oder persönliche informationen.\n\n\n
 Kontaktiere mich:</string>
     <string name="action_about">Über</string>
+    <string name="action_privacy_policy">Datenschutzerklärung</string>
     <string name="action_licence">Lizenzen</string>
     <string name="rootAvailable">Root zugriff vorhanden</string>
     <string name="rootUnknown">Root zugriff konnte nicht ermittelt werden</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="rootNotAvailable">Your Device doesn\'t have Root access</string>
     <string name="action_licence">Licenses</string>
     <string name="action_about">About</string>
+    <string name="action_privacy_policy">Privacy Policy</string>
     <string name="textViewAndroidVersion">Android</string>
     <string name="string_your_device">Your Device</string>
     <string name="string_checking_for_root">Checking for Root…</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ boehrsi-devicemarketingnames = "1.0.5"          # https://github.com/Boehrsi/Dev
 google-material = "1.13.0"
 kotlinx-collections-immutable = "0.4.0"
 kotlinx-serialization-core = "1.10.0"
+telemetrydeck = "6.3.0"                          # https://github.com/TelemetryDeck/KotlinSDK/releases
 topjohnwu-libsu-core = "6.0.0"                  # https://github.com/topjohnwu/libsu/releases
 
 [libraries]
@@ -35,6 +36,7 @@ boehrsi-devicemarketingnames = { module = "de.boehrsi:devicemarketingnames", ver
 google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization-core" }
+telemetrydeck-sdk = { module = "com.telemetrydeck:kotlin-sdk", version.ref = "telemetrydeck" }
 topjohnwu-libsu-core = { module = "com.github.topjohnwu.libsu:core", version.ref = "topjohnwu-libsu-core" }
 
 [plugins]


### PR DESCRIPTION
Integrates TelemetryDeck Kotlin SDK (v6.3.0) using manifest-based
auto-initialization. Tracks screen navigation and root check events.
The app ID is injected via manifestPlaceholders — replace the
placeholder in build.gradle.kts with your TelemetryDeck App ID.

https://claude.ai/code/session_016VUojgLuQwrpJxB4Wy7VCP